### PR TITLE
Replace record.msg with getMessage() as it has all the variables parsed

### DIFF
--- a/jslog4kube/kube/metadata_injector.py
+++ b/jslog4kube/kube/metadata_injector.py
@@ -50,7 +50,7 @@ class KubeMetaInject(logging.Filter):
             setattr(record, k, v)
 
         if record.name == 'gunicorn.access':
-            msg = record.msg
+            msg = record.getMessage()
             try:
                 msg_elements = {
                     k: v


### PR DESCRIPTION
I think this is a fix for just more recent versions of gunicorn, but i can't easily setup older versions to test.